### PR TITLE
Additional evaluations - Init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ neardev
 
 # PRODUCTION
 /build
+build
 
 # MISC
 .DS_Store

--- a/additional_evaluations/js-ts/contract_init/README.md
+++ b/additional_evaluations/js-ts/contract_init/README.md
@@ -1,0 +1,39 @@
+# Hello NEAR Contract
+
+The smart contract exposes two methods to enable storing and retrieving a greeting in the NEAR network.
+
+```ts
+@NearBindgen({})
+class HelloNear {
+  greeting: string = "Hello";
+
+  @view // This method is read-only and can be called for free
+  get_greeting(): string {
+    return this.greeting;
+  }
+
+  @call // This method changes the state, for which it cost gas
+  set_greeting({ greeting }: { greeting: string }): void {
+    // Record a log permanently to the blockchain!
+    near.log(`Saving greeting ${greeting}`);
+    this.greeting = greeting;
+  }
+}
+```
+
+<br />
+
+# Quickstart
+
+1. Make sure you have installed [node.js](https://nodejs.org/en/download/package-manager/) >= 16.
+2. Install the [`NEAR CLI`](https://github.com/near/near-cli#setup)
+
+<br />
+
+## 1. Build and Deploy the Contract
+You can automatically compile and deploy the contract in the NEAR testnet by running:
+
+```bash
+npm run build
+npm run deploy
+```

--- a/additional_evaluations/js-ts/contract_init/README.md
+++ b/additional_evaluations/js-ts/contract_init/README.md
@@ -1,39 +1,11 @@
-# Hello NEAR Contract
+# Initialize a Hello NEAR Contract
 
-The smart contract exposes two methods to enable storing and retrieving a greeting in the NEAR network.
-
-```ts
-@NearBindgen({})
-class HelloNear {
-  greeting: string = "Hello";
-
-  @view // This method is read-only and can be called for free
-  get_greeting(): string {
-    return this.greeting;
-  }
-
-  @call // This method changes the state, for which it cost gas
-  set_greeting({ greeting }: { greeting: string }): void {
-    // Record a log permanently to the blockchain!
-    near.log(`Saving greeting ${greeting}`);
-    this.greeting = greeting;
-  }
-}
-```
+This test builds on top of the standard `hello near` example contract. We are required to write a init function called `init` that takes a string as an argument and initializes the contract's state.
 
 <br />
 
 # Quickstart
 
 1. Make sure you have installed [node.js](https://nodejs.org/en/download/package-manager/) >= 16.
-2. Install the [`NEAR CLI`](https://github.com/near/near-cli#setup)
-
-<br />
-
-## 1. Build and Deploy the Contract
-You can automatically compile and deploy the contract in the NEAR testnet by running:
-
-```bash
-npm run build
-npm run deploy
-```
+2. Use `npm run build` to build the contract
+3. Use `npm run test` to run the tests

--- a/additional_evaluations/js-ts/contract_init/package.json
+++ b/additional_evaluations/js-ts/contract_init/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "hello_near",
+  "version": "1.0.0",
+  "license": "(MIT AND Apache-2.0)",
+  "engines": {
+    "node": "16.x"
+  },
+  "type": "module",
+  "scripts": {
+    "build": "near-sdk-js build src/contract.ts build/hello_near.wasm",
+    "deploy": "near dev-deploy --wasmFile build/hello_near.wasm",
+    "test": "cd sandbox-ts && $npm_execpath run test -- -- ../build/hello_near.wasm",
+    "postinstall": "cd sandbox-ts && $npm_execpath i"
+  },
+  "dependencies": {
+    "near-cli": "^3.4.2",
+    "near-sdk-js": "1.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "ts-morph": "^20.0.0"
+  }
+}

--- a/additional_evaluations/js-ts/contract_init/sandbox-ts/ava.config.cjs
+++ b/additional_evaluations/js-ts/contract_init/sandbox-ts/ava.config.cjs
@@ -1,0 +1,9 @@
+require("util").inspect.defaultOptions.depth = 5; // Increase AVA's printing depth
+
+module.exports = {
+  timeout: "300000",
+  files: ["src/*.ava.ts"],
+  failWithoutAssertions: false,
+  extensions: ["ts"],
+  require: ["ts-node/register"],
+};

--- a/additional_evaluations/js-ts/contract_init/sandbox-ts/package.json
+++ b/additional_evaluations/js-ts/contract_init/sandbox-ts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ava-testing",
+  "version": "1.0.0",
+  "license": "(MIT AND Apache-2.0)",
+  "engines": {
+    "node": "16.x"
+  },
+  "scripts": {
+    "test": "ava"
+  },
+  "devDependencies": {
+    "@types/bn.js": "^5.1.4",
+    "@types/node": "^20.8.10",
+    "ava": "^5.3.1",
+    "near-workspaces": "^3.3.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  },
+  "dependencies": {}
+}

--- a/additional_evaluations/js-ts/contract_init/sandbox-ts/src/main.ava.ts
+++ b/additional_evaluations/js-ts/contract_init/sandbox-ts/src/main.ava.ts
@@ -29,6 +29,12 @@ test.afterEach.always(async (t) => {
     console.log('Failed to stop the Sandbox:', error);
   });
 });
+test('initializes the greeting', async (t) => {
+  const { root, contract } = t.context.accounts;
+  await root.call(contract, 'init', { greeting: 'Hello World!' });
+  const greeting: string = await contract.view('get_greeting', {});
+  t.is(greeting, 'Hello World!');
+});
 
 test('returns the default greeting', async (t) => {
   const { contract } = t.context.accounts;

--- a/additional_evaluations/js-ts/contract_init/sandbox-ts/src/main.ava.ts
+++ b/additional_evaluations/js-ts/contract_init/sandbox-ts/src/main.ava.ts
@@ -1,0 +1,44 @@
+import { Worker, NearAccount } from 'near-workspaces';
+import anyTest, { TestFn } from 'ava';
+
+const test = anyTest as TestFn<{
+  worker: Worker;
+  accounts: Record<string, NearAccount>;
+}>;
+
+test.beforeEach(async (t) => {
+  // Init the worker and start a Sandbox server
+  const worker = await Worker.init();
+
+  // Deploy contract
+  const root = worker.rootAccount;
+  const contract = await root.createSubAccount('test-account');
+  // Get wasm file path from package.json test script in folder above
+  await contract.deploy(
+    process.argv[2],
+  );
+
+  // Save state for test runs, it is unique for each test
+  t.context.worker = worker;
+  t.context.accounts = { root, contract };
+});
+
+test.afterEach.always(async (t) => {
+  // Stop Sandbox server
+  await t.context.worker.tearDown().catch((error) => {
+    console.log('Failed to stop the Sandbox:', error);
+  });
+});
+
+test('returns the default greeting', async (t) => {
+  const { contract } = t.context.accounts;
+  const greeting: string = await contract.view('get_greeting', {});
+  t.is(greeting, 'Hello');
+});
+
+test('changes the greeting', async (t) => {
+  const { root, contract } = t.context.accounts;
+  await root.call(contract, 'set_greeting', { greeting: 'Howdy' });
+  const greeting: string = await contract.view('get_greeting', {});
+  t.is(greeting, 'Howdy');
+});

--- a/additional_evaluations/js-ts/contract_init/src/contract.ts
+++ b/additional_evaluations/js-ts/contract_init/src/contract.ts
@@ -1,5 +1,5 @@
 // Find all our documentation at https://docs.near.org
-import { NearBindgen, near, call, view } from 'near-sdk-js';
+import { NearBindgen, near, call, view, initialize } from 'near-sdk-js';
 
 @NearBindgen({})
 class HelloNear {
@@ -7,12 +7,11 @@ class HelloNear {
   // DO NOT MODIFY THE CODE ABOVE
   // ===========================================================================
 
-  // Write your init function `new` here
+  // Write your initialization function `init` here
 
 
   // DO NOT MODIFY THE CODE BELLOW
   // ===========================================================================
-
   @view({}) // This method is read-only and can be called for free
   get_greeting(): string {
     return this.greeting;

--- a/additional_evaluations/js-ts/contract_init/src/contract.ts
+++ b/additional_evaluations/js-ts/contract_init/src/contract.ts
@@ -1,0 +1,26 @@
+// Find all our documentation at https://docs.near.org
+import { NearBindgen, near, call, view } from 'near-sdk-js';
+
+@NearBindgen({})
+class HelloNear {
+  greeting: string = "Hello";
+  // DO NOT MODIFY THE CODE ABOVE
+  // ===========================================================================
+
+  // Write your init function `new` here
+
+
+  // DO NOT MODIFY THE CODE BELLOW
+  // ===========================================================================
+
+  @view({}) // This method is read-only and can be called for free
+  get_greeting(): string {
+    return this.greeting;
+  }
+
+  @call({}) // This method changes the state, for which it cost gas
+  set_greeting({ greeting }: { greeting: string }): void {
+    near.log(`Saving greeting ${greeting}`);
+    this.greeting = greeting;
+  }
+}

--- a/additional_evaluations/js-ts/contract_init/tsconfig.json
+++ b/additional_evaluations/js-ts/contract_init/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "target": "es5",
+    "noEmit": true
+  },
+  "exclude": [
+    "node_modules"
+  ],
+}

--- a/additional_evaluations/rust/contract_init/.cargo/config
+++ b/additional_evaluations/rust/contract_init/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "link-args=-s"]

--- a/additional_evaluations/rust/contract_init/Cargo.toml
+++ b/additional_evaluations/rust/contract_init/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "hello_near"
+version = "1.0.0"
+authors = ["Near Inc <hello@near.org>"]
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+near-sdk = "4.1.1"
+uint = { version = "0.9.3", default-features = false }
+
+[profile.release]
+codegen-units = 1
+opt-level = "z"
+lto = true
+debug = false
+panic = "abort"
+overflow-checks = true

--- a/additional_evaluations/rust/contract_init/README.md
+++ b/additional_evaluations/rust/contract_init/README.md
@@ -1,0 +1,11 @@
+# Initialize a Hello NEAR Contract
+
+This test builds on top of the standard `hello near` example contract. We are required to write a init function called `new` that takes a string as an argument and initializes the contract's state.
+
+<br />
+
+# Quickstart
+
+1. If you don't have rust already installed check out the [NEAR docs](https://docs.near.org/sdk/rust/get-started)
+2. Use `yarn --cwd sandbox-ts` to install dependencies
+3. Use `./test.sh` script to run the tests

--- a/additional_evaluations/rust/contract_init/build.sh
+++ b/additional_evaluations/rust/contract_init/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+rustup target add wasm32-unknown-unknown
+cargo build --target wasm32-unknown-unknown --release

--- a/additional_evaluations/rust/contract_init/deploy.sh
+++ b/additional_evaluations/rust/contract_init/deploy.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+near dev-deploy --wasmFile ./target/wasm32-unknown-unknown/release/hello_near.wasm

--- a/additional_evaluations/rust/contract_init/rust-toolchain.toml
+++ b/additional_evaluations/rust/contract_init/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.69"

--- a/additional_evaluations/rust/contract_init/sandbox-ts/ava.config.cjs
+++ b/additional_evaluations/rust/contract_init/sandbox-ts/ava.config.cjs
@@ -1,0 +1,9 @@
+require("util").inspect.defaultOptions.depth = 5; // Increase AVA's printing depth
+
+module.exports = {
+  timeout: "300000",
+  files: ["src/*.ava.ts"],
+  failWithoutAssertions: false,
+  extensions: ["ts"],
+  require: ["ts-node/register"],
+};

--- a/additional_evaluations/rust/contract_init/sandbox-ts/package.json
+++ b/additional_evaluations/rust/contract_init/sandbox-ts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ava-testing",
+  "version": "1.0.0",
+  "license": "(MIT AND Apache-2.0)",
+  "engines": {
+    "node": "16.x"
+  },
+  "scripts": {
+    "test": "ava"
+  },
+  "devDependencies": {
+    "@types/bn.js": "^5.1.4",
+    "@types/node": "^20.8.10",
+    "ava": "^5.3.1",
+    "near-workspaces": "^3.3.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  },
+  "dependencies": {}
+}

--- a/additional_evaluations/rust/contract_init/sandbox-ts/src/main.ava.ts
+++ b/additional_evaluations/rust/contract_init/sandbox-ts/src/main.ava.ts
@@ -1,0 +1,54 @@
+import { Worker, NearAccount } from 'near-workspaces';
+import anyTest, { TestFn } from 'ava';
+
+const test = anyTest as TestFn<{
+  worker: Worker;
+  accounts: Record<string, NearAccount>;
+}>;
+
+test.beforeEach(async (t) => {
+  // Init the worker and start a Sandbox server
+  const worker = await Worker.init();
+
+  // Deploy contract
+  const root = worker.rootAccount;
+  const contract = await root.createSubAccount('test-account');
+  // Get wasm file path from package.json test script in folder above
+  await contract.deploy(
+    process.argv[2],
+  );
+
+  // Save state for test runs, it is unique for each test
+  t.context.worker = worker;
+  t.context.accounts = { root, contract };
+});
+
+test.afterEach.always(async (t) => {
+  // Stop Sandbox server
+  await t.context.worker.tearDown().catch((error) => {
+    console.log('Failed to stop the Sandbox:', error);
+  });
+});
+
+
+test('initializes the greeting', async (t) => {
+  const { root, contract } = t.context.accounts;
+  await root.call(contract, 'new', { greeting: 'Hello World!' });
+  const greeting: string = await contract.view('get_greeting', {});
+  t.is(greeting, 'Hello World!');
+});
+
+test('returns the default greeting', async (t) => {
+  const { contract } = t.context.accounts;
+  const greeting: string = await contract.view('get_greeting', {});
+  t.is(greeting, 'Hello');
+});
+
+
+
+test('changes the greeting', async (t) => {
+  const { root, contract } = t.context.accounts;
+  await root.call(contract, 'set_greeting', { greeting: 'Howdy' });
+  const greeting: string = await contract.view('get_greeting', {});
+  t.is(greeting, 'Howdy');
+});

--- a/additional_evaluations/rust/contract_init/src/lib.rs
+++ b/additional_evaluations/rust/contract_init/src/lib.rs
@@ -1,0 +1,64 @@
+// Find all our documentation at https://docs.near.org
+use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::env::log_str;
+use near_sdk::near_bindgen;
+
+// Define the contract structure
+#[near_bindgen]
+#[derive(BorshDeserialize, BorshSerialize)]
+pub struct Contract {
+    greeting: String,
+}
+
+// Define the default, which automatically initializes the contract
+impl Default for Contract {
+    fn default() -> Self {
+        Self {
+            greeting: "Hello".to_string(),
+        }
+    }
+}
+// =============================================================================
+// DON'T MODIFY THE CODE ABOVE
+
+// Implement the contract structure
+#[near_bindgen]
+impl Contract {
+    // ADD YOUR INIT METHOD HERE
+
+    // DON'T MODIFY THE CODE BELLOW
+    // =========================================================================
+    // Public method - returns the greeting saved, defaulting to DEFAULT_GREETING
+    pub fn get_greeting(&self) -> String {
+        return self.greeting.clone();
+    }
+
+    // Public method - accepts a greeting, such as "howdy", and records it
+    pub fn set_greeting(&mut self, greeting: String) {
+        log_str(&format!("Saving greeting: {greeting}"));
+        self.greeting = greeting;
+    }
+}
+
+/*
+ * The rest of this file holds the inline tests for the code above
+ * Learn more about Rust tests: https://doc.rust-lang.org/book/ch11-01-writing-tests.html
+ */
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_default_greeting() {
+        let contract = Contract::default();
+        // this test did not call set_greeting so should return the default "Hello" greeting
+        assert_eq!(contract.get_greeting(), "Hello".to_string());
+    }
+
+    #[test]
+    fn set_then_get_greeting() {
+        let mut contract = Contract::default();
+        contract.set_greeting("howdy".to_string());
+        assert_eq!(contract.get_greeting(), "howdy".to_string());
+    }
+}

--- a/additional_evaluations/rust/contract_init/test.sh
+++ b/additional_evaluations/rust/contract_init/test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# unit testing
+cargo test
+
+# sandbox testing
+./build.sh
+cd sandbox-ts
+npm i
+npm run test -- -- "../target/wasm32-unknown-unknown/release/hello_near.wasm"


### PR DESCRIPTION
Adds additional validations for both TS and Rust contracts extends the familiar hello near contract. Shows that we can use both default state and initialization methods. Closes #7 